### PR TITLE
Add simple Flask web app

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,29 @@
+from flask import Flask, render_template, request
+from enhancement_engine import EnhancementEngine
+
+app = Flask(__name__)
+
+# For demo purposes we create the engine once. In a real app this might be
+# configured differently or use dependency injection.
+engine = EnhancementEngine(email="demo@example.com")
+
+
+@app.route("/", methods=["GET"])
+def index() -> str:
+    """Render the input form."""
+    return render_template("index.html")
+
+
+@app.route("/analyze", methods=["POST"])
+def analyze() -> str:
+    """Run a simple gene analysis and display the result."""
+    gene = request.form.get("gene", "").strip()
+    variant = request.form.get("variant", "enhancement_variant").strip()
+    if not gene:
+        return render_template("index.html", error="Gene name is required")
+
+    report = engine.analyze_gene(gene, variant)
+    return render_template("result.html", report=report)
+
+
+__all__ = ["app"]

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Enhancement Engine</title>
+</head>
+<body>
+    <h1>Gene Analysis</h1>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form action="{{ url_for('analyze') }}" method="post">
+        <label for="gene">Gene:</label>
+        <input type="text" name="gene" id="gene">
+        <label for="variant">Variant:</label>
+        <input type="text" name="variant" id="variant">
+        <button type="submit">Analyze</button>
+    </form>
+</body>
+</html>

--- a/webapp/templates/result.html
+++ b/webapp/templates/result.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Analysis Result</title>
+</head>
+<body>
+    <h1>Analysis Result</h1>
+    <p>Gene: {{ report.gene_name }}</p>
+    <p>Feasibility: {{ report.feasibility_score }}</p>
+    <p>Safety score: {{ report.safety_assessment.overall_score }}</p>
+    <p>Predicted improvement: {{ report.predicted_effect.enhancement_gain.improvement_factor }}x</p>
+    <p><a href="{{ url_for('index') }}">Analyze another gene</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `webapp` package
- implement Flask app using EnhancementEngine
- provide placeholder HTML templates

## Testing
- `flake8 webapp` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840968c8f70832995477cdc70477acd