### PR TITLE
Add basic Flask webapp and its tests

### DIFF
--- a/enhancement_engine/webapp.py
+++ b/enhancement_engine/webapp.py
@@ -1,0 +1,28 @@
+from flask import Flask, request, jsonify
+
+from .core.engine import EnhancementEngine
+
+app = Flask(__name__)
+
+# Create a single engine instance for simplicity
+_engine = EnhancementEngine(email="webapp@example.com")
+
+
+@app.route("/")
+def index():
+    """Simple index route."""
+    return "Enhancement Engine", 200
+
+
+@app.route("/analyze")
+def analyze():
+    """Analyze a gene via query parameters."""
+    gene = request.args.get("gene")
+    variant = request.args.get("variant", "enhancement_variant")
+    target = request.args.get("target", "general")
+
+    if not gene:
+        return jsonify({"error": "gene parameter required"}), 400
+
+    report = _engine.analyze_gene(gene, variant, target)
+    return jsonify({"gene_name": report.gene_name})

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,33 @@
+import pytest
+
+pytest.importorskip("flask")
+
+try:
+    from enhancement_engine.webapp import app
+    from enhancement_engine.core.engine import EnhancementEngine
+except Exception:  # pragma: no cover - skip if webapp missing
+    pytest.skip("webapp not available", allow_module_level=True)
+
+
+def test_index_page():
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+
+
+def test_analyze_route(monkeypatch):
+    called = {}
+
+    def fake_analyze_gene(self, gene_name, variant="enhancement_variant", target_tissue="general"):
+        called['gene'] = gene_name
+        class R:
+            def __init__(self, gene_name):
+                self.gene_name = gene_name
+        return R(gene_name)
+
+    monkeypatch.setattr(EnhancementEngine, "analyze_gene", fake_analyze_gene)
+
+    client = app.test_client()
+    resp = client.get("/analyze?gene=COMT")
+    assert resp.status_code == 200
+    assert called['gene'] == "COMT"


### PR DESCRIPTION
## Summary
- add a minimal Flask webapp with `/` and `/analyze` routes
- test webapp endpoints using Flask's `test_client`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684096f54ecc8329a3257904d30be103