### PR TITLE
Add web interface docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ enhancement-engine batch COMT,BDNF,ACTN3 -e your.email@domain.com
 enhancement-engine cache stats -e your.email@domain.com
 ```
 
+### Web Interface
+
+An optional web-based UI built with [Flask](https://flask.palletsprojects.com/) is included.
+Install the extra dependency and launch the app:
+
+```bash
+pip install Flask
+python examples/webapp.py
+```
+
+The server runs on `http://127.0.0.1:5000/`. POST a JSON payload with `gene` and
+`variant` to `/analyze` to retrieve an analysis report. A brief walkthrough is
+available in [docs/webapp_guide.md](docs/webapp_guide.md).
+
 ## 🧬 Supported Enhancement Genes
 
 | Gene | Function | Enhancement Type |

--- a/docs/webapp_guide.md
+++ b/docs/webapp_guide.md
@@ -1,0 +1,24 @@
+# Web App Guide
+
+This short guide shows how to start the optional Flask web interface.
+
+## Installation
+
+Install Flask if it is not already available:
+
+```bash
+pip install Flask
+```
+
+## Running the App
+
+A minimal application is provided in the `examples` folder. Start it with:
+
+```bash
+python examples/webapp.py
+```
+
+Once the server is running, open `http://127.0.0.1:5000/` in your browser. Send a
+POST request to `/analyze` containing `gene` and `variant` fields to receive a
+JSON analysis report.
+

--- a/examples/webapp.py
+++ b/examples/webapp.py
@@ -1,0 +1,40 @@
+"""Minimal Flask web interface for Enhancement Engine."""
+
+from flask import Flask, jsonify, request
+
+from enhancement_engine import EnhancementEngine
+
+app = Flask(__name__)
+engine = EnhancementEngine(email="demo@example.com")
+
+
+@app.route("/")
+def index() -> str:
+    """Simple index route."""
+    return "Enhancement Engine Web API"
+
+
+@app.route("/analyze", methods=["POST"])
+def analyze() -> tuple:
+    """Run a gene analysis and return JSON."""
+    data = request.get_json() or {}
+    gene = data.get("gene")
+    variant = data.get("variant")
+    if not gene or not variant:
+        return jsonify({"error": "gene and variant required"}), 400
+
+    report = engine.analyze_gene(gene, variant)
+    return (
+        jsonify(
+            gene=gene,
+            variant=variant,
+            enhancement_gain=report.enhancement_gain,
+            safety_score=report.safety_assessment.safety_score,
+        ),
+        200,
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)
+


### PR DESCRIPTION
## Summary
- document optional Flask web interface
- provide a simple Flask example app
- add quick walkthrough in `docs/webapp_guide.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840970deb2083299c7dbd822a378c6d