### PR TITLE
Fix Biopython compatibility

### DIFF
--- a/enhancement_engine/core/crispr.py
+++ b/enhancement_engine/core/crispr.py
@@ -19,7 +19,15 @@ import itertools
 try:
     from Bio.Seq import Seq
     from Bio.SeqRecord import SeqRecord
-    from Bio.SeqUtils import GC
+
+    try:  # Older BioPython
+        from Bio.SeqUtils import GC
+    except ImportError:  # Newer BioPython versions
+        from Bio.SeqUtils import gc_fraction
+
+        def GC(seq) -> float:
+            """Return GC percentage for *seq* as a float."""
+            return gc_fraction(seq) * 100
 except ImportError:
     raise ImportError("BioPython is required. Install with: pip install biopython")
 

--- a/enhancement_engine/core/engine.py
+++ b/enhancement_engine/core/engine.py
@@ -79,11 +79,12 @@ class EnhancementEngine:
             project_name="Enhancement Analysis", researcher_email=email
         )
 
+        # Setup logging early so component init can use it
+        self.logger = logging.getLogger(__name__)
+
         # Initialize all analysis components
         self._initialize_components()
 
-        # Setup logging
-        self.logger = logging.getLogger(__name__)
         self.logger.info(f"Enhancement Engine initialized for {email}")
 
         # Analysis cache for performance

--- a/enhancement_engine/core/sequence.py
+++ b/enhancement_engine/core/sequence.py
@@ -19,8 +19,16 @@ import numpy as np
 try:
     from Bio.Seq import Seq
     from Bio.SeqRecord import SeqRecord
-    from Bio.SeqUtils import GC, molecular_weight
     from Bio import SeqIO
+
+    try:  # BioPython <1.78 provided GC directly
+        from Bio.SeqUtils import GC, molecular_weight
+    except ImportError:  # BioPython >=1.78 moved GC -> gc_fraction
+        from Bio.SeqUtils import gc_fraction, molecular_weight
+
+        def GC(seq) -> float:
+            """Return GC percentage for *seq* as a float."""
+            return gc_fraction(seq) * 100
 except ImportError:
     raise ImportError("BioPython is required. Install with: pip install biopython")
 


### PR DESCRIPTION
## Summary
- handle Biopython's removal of `GC` by falling back to `gc_fraction`
- initialize logger before creating engine components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409e123ec48329bbf1a90d03587466