### PR TITLE
Add therapeutic analysis route

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -136,8 +136,14 @@
                     <!-- Safety Warning -->
                     <div class="alert alert-warning mt-4" role="alert">
                         <i class="fas fa-shield-alt me-2"></i>
-                        <strong>Safety & Ethics:</strong> This tool is for research and educational purposes only. 
+                        <strong>Safety & Ethics:</strong> This tool is for research and educational purposes only.
                         Any practical application requires proper ethical review, safety testing, and regulatory approval.
+                    </div>
+
+                    <div class="text-center mt-3">
+                        <a href="{{ url_for('therapeutic') }}" class="btn btn-outline-secondary">
+                            Test Therapeutic Mode
+                        </a>
                     </div>
                 </div>
             </div>

--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Therapeutic Testing - Enhancement Engine</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <h1 class="mb-4 text-center">Therapeutic Testing</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        {% for category, message in messages %}
+        <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+        {% endfor %}
+    {% endif %}
+    {% endwith %}
+
+    {% if report %}
+    <div class="alert alert-success">
+        <h4 class="alert-heading">Recommendation: {{ report.treatment_recommendation }}</h4>
+        <p>Safety Score: {{ report.safety_assessment.overall_safety_score }}</p>
+        <p>Efficacy: {{ "%.2f"|format(report.predicted_efficacy.overall_efficacy) }}</p>
+        <p>Confidence: {{ "%.2f"|format(report.confidence_score) }}</p>
+    </div>
+    {% endif %}
+
+    <form method="post">
+        <div class="mb-3">
+            <label for="gene" class="form-label">Gene Symbol</label>
+            <input type="text" class="form-control" id="gene" name="gene" required>
+        </div>
+        <div class="mb-3">
+            <label for="variant" class="form-label">Variant</label>
+            <input type="text" class="form-control" id="variant" name="variant">
+        </div>
+        <div class="mb-3">
+            <label for="disease" class="form-label">Disease</label>
+            <input type="text" class="form-control" id="disease" name="disease" value="rheumatoid_arthritis">
+        </div>
+        <div class="mb-3">
+            <label for="age" class="form-label">Patient Age</label>
+            <input type="number" class="form-control" id="age" name="age">
+        </div>
+        <button type="submit" class="btn btn-primary">Run Therapeutic Analysis</button>
+        <a href="{{ url_for('index') }}" class="btn btn-secondary ms-2">Back</a>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add therapeutic engine and route to webapp
- provide simple therapeutic HTML template
- link from index to new route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bf9b77a88329a0dd04c10c45676a