### PR TITLE
Document therapeutic CLI/webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ the HTML form or POST a JSON payload with `gene` and `variant` to `/analyze` to
 retrieve an analysis report. A brief walkthrough is available in
 [docs/webapp_guide.md](docs/webapp_guide.md).
 
+## 🩺 Therapeutic Engine
+
+The project also includes a therapeutic pipeline aimed at disease correction.
+The `TherapeuticEnhancementEngine` integrates risk assessment, CRISPR design and
+clinical safety modules.
+
+### CLI Usage
+
+Run a therapeutic analysis from the command line with:
+
+```bash
+enhancement-engine therapeutic PTPN22 --variant R620W \
+    --disease rheumatoid_arthritis -e you@example.com
+```
+
+### Webapp
+
+Start the Flask app and navigate to `/therapeutic` for an HTML form or POST JSON
+to `/api/therapeutic`.
+
 ## 🧬 Supported Enhancement Genes
 
 | Gene | Function | Enhancement Type |
@@ -175,6 +195,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - [User Guide](docs/user_guide.md)
 - [API Reference](docs/api_reference.md)
+- [Therapeutic Engine](docs/therapeutic_engine.md)
 - [Examples](examples/)
 - [FAQ](docs/faq.md)
 

--- a/docs/therapeutic_engine.md
+++ b/docs/therapeutic_engine.md
@@ -1,0 +1,28 @@
+# Therapeutic Engine
+
+The therapeutic pipeline extends the core engine to evaluate CRISPR-based disease correction strategies.
+It performs disease risk analysis, designs correction guides and estimates clinical safety.
+
+## Quick Example
+
+```python
+from enhancement_engine.core.therapeutic_engine import TherapeuticEnhancementEngine
+
+engine = TherapeuticEnhancementEngine(email="you@example.com")
+report = engine.analyze_disease_gene(
+    "PTPN22", "R620W", {"age": 45}, disease="rheumatoid_arthritis"
+)
+print(report.summary)
+```
+
+### Command Line
+
+```bash
+enhancement-engine therapeutic PTPN22 --variant R620W \
+    --disease rheumatoid_arthritis -e you@example.com
+```
+
+### Web Interface
+
+Launch the app with `enhancement-engine-web` and open `/therapeutic` or POST to
+`/api/therapeutic` with `gene`, `variant` and `disease` fields.


### PR DESCRIPTION
## Summary
- document how to run the therapeutic engine in README
- add a dedicated doc page describing the therapeutic pipeline

## Testing
- `flake8` *(fails: numerous style issues in repo)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bfa1512c8329a713c27d4f9dd631