### PR TITLE
Add ClinVar client for dynamic disease data

### DIFF
--- a/enhancement_engine/core/__init__.py
+++ b/enhancement_engine/core/__init__.py
@@ -1,0 +1,1 @@
+from .disease_db import DiseaseDatabaseClient

--- a/enhancement_engine/core/disease_db.py
+++ b/enhancement_engine/core/disease_db.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+"""ClinVar/MedGen client for disease information."""
+
+import logging
+from typing import Dict, Optional
+
+from .database import CacheManager
+
+try:
+    from Bio import Entrez
+except ImportError:  # pragma: no cover - biopython required
+    Entrez = None  # type: ignore
+
+
+class DiseaseDatabaseClient:
+    """Query ClinVar/MedGen for disease risk data."""
+
+    def __init__(self, email: str, cache_dir: str = "data/cache/disease_db"):
+        if Entrez is None:
+            raise ImportError("Biopython is required for DiseaseDatabaseClient")
+        Entrez.email = email
+        self.logger = logging.getLogger(__name__)
+        self.cache = CacheManager(cache_dir)
+
+    def fetch_disease_info(
+        self, gene: str, variant: str, disease: Optional[str] = None
+    ) -> Optional[Dict[str, float]]:
+        """Fetch odds ratio, allele frequency and penetrance."""
+        cache_key = f"{gene}_{variant}_{disease}"
+        cached = self.cache.get(cache_key, "disease")
+        if cached:
+            return cached
+
+        # ensure disease cache directory exists
+        (self.cache.cache_dir / "disease").mkdir(exist_ok=True)
+
+        query_parts = [gene]
+        if variant:
+            query_parts.append(variant)
+        if disease:
+            query_parts.append(disease)
+        query = " AND ".join(query_parts)
+
+        try:
+            search_handle = Entrez.esearch(db="clinvar", term=query, retmax=1)
+            search_result = Entrez.read(search_handle)
+            search_handle.close()
+            ids = search_result.get("IdList", [])
+            if not ids:
+                return None
+            summary_handle = Entrez.esummary(db="clinvar", id=ids[0])
+            summary = Entrez.read(summary_handle)
+            summary_handle.close()
+            doc = summary[0] if summary else {}
+            data = {
+                "odds_ratio": float(doc.get("OddsRatio", 1.0)),
+                "allele_frequency": float(doc.get("AlleleFrequency", 0.0)),
+                "penetrance": float(doc.get("Penetrance", 0.1)),
+            }
+            self.cache.set(cache_key, data, "disease")
+            return data
+        except Exception as exc:  # pragma: no cover - network errors
+            self.logger.warning(f"Failed to query ClinVar: {exc}")
+            return None

--- a/enhancement_engine/core/therapeutic_engine.py
+++ b/enhancement_engine/core/therapeutic_engine.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from .engine import EnhancementEngine
 from .disease_risk import DiseaseRiskCalculator, MultiGeneRiskCalculator
+from .disease_db import DiseaseDatabaseClient
 from .therapeutic_crispr import TherapeuticCRISPRDesigner
 from .therapeutic_safety import TherapeuticSafetyAnalyzer
 from .database import GeneDatabase
@@ -79,9 +80,10 @@ class TherapeuticEnhancementEngine:
         try:
             # Core enhancement engine for basic functionality
             self.base_engine = EnhancementEngine(self.email)
-            
+
             # Therapeutic-specific components
-            self.disease_risk_calculator = DiseaseRiskCalculator()
+            self.disease_db_client = DiseaseDatabaseClient(self.email)
+            self.disease_risk_calculator = DiseaseRiskCalculator(self.disease_db_client)
             self.multigene_risk_calculator = MultiGeneRiskCalculator()
             self.therapeutic_crispr_designer = TherapeuticCRISPRDesigner()
             self.therapeutic_safety_analyzer = TherapeuticSafetyAnalyzer()

--- a/tests/test_disease_db.py
+++ b/tests/test_disease_db.py
@@ -1,0 +1,52 @@
+import pytest
+from enhancement_engine.core.disease_db import DiseaseDatabaseClient
+
+class DummyHandle:
+    def __init__(self, name):
+        self.name = name
+    def close(self):
+        pass
+
+
+def test_fetch_disease_info_cached(monkeypatch, tmp_path):
+    calls = {"esearch": 0, "esummary": 0}
+
+    def fake_esearch(db, term, retmax=1):
+        calls["esearch"] += 1
+        return DummyHandle("search")
+
+    def fake_esummary(db, id):
+        calls["esummary"] += 1
+        return DummyHandle("summary")
+
+    def fake_read(handle):
+        if handle.name == "search":
+            return {"IdList": ["1"]}
+        return [{"OddsRatio": "2.0", "AlleleFrequency": "0.05", "Penetrance": "0.1"}]
+
+    monkeypatch.setattr("enhancement_engine.core.disease_db.Entrez.esearch", fake_esearch)
+    monkeypatch.setattr("enhancement_engine.core.disease_db.Entrez.esummary", fake_esummary)
+    monkeypatch.setattr("enhancement_engine.core.disease_db.Entrez.read", fake_read)
+
+    client = DiseaseDatabaseClient("test@example.com", cache_dir=str(tmp_path))
+    info1 = client.fetch_disease_info("GENE", "VAR", "disease")
+    assert info1 == {"odds_ratio": 2.0, "allele_frequency": 0.05, "penetrance": 0.1}
+    info2 = client.fetch_disease_info("GENE", "VAR", "disease")
+    assert info2 == info1
+    assert calls["esearch"] == 1
+    assert calls["esummary"] == 1
+
+
+def test_risk_calculator_dynamic(monkeypatch):
+    from enhancement_engine.core.disease_risk import DiseaseRiskCalculator
+
+    class DummyClient:
+        def fetch_disease_info(self, gene, variant, disease=None):
+            return {"odds_ratio": 1.5, "allele_frequency": 0.1, "penetrance": 0.05}
+
+    calc = DiseaseRiskCalculator(DummyClient())
+    patient = {"ethnicity": "european", "age": 40, "sex": "female"}
+    risk = calc.calculate_disease_risk("UNKNOWN", "VAR", patient, "rare")
+    assert pytest.approx(risk.odds_ratio) == 1.5
+    assert risk.population_frequency == 0.1
+    assert risk.penetrance > 0


### PR DESCRIPTION
## Summary
- add `DiseaseDatabaseClient` to query ClinVar/MedGen and cache results
- integrate dynamic client with `DiseaseRiskCalculator`
- pass new client in `TherapeuticEnhancementEngine`
- unit tests for dynamic retrieval and caching

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c9d767d88329b9ad40b54787a787