### PR TITLE
Add disease suggestions endpoint with autocomplete

### DIFF
--- a/enhancement_engine/webapp.py
+++ b/enhancement_engine/webapp.py
@@ -1,0 +1,5 @@
+from webapp.run import create_app
+
+# Expose a Flask app instance for tests
+app = create_app()
+

--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -70,7 +70,8 @@
         </div>
         <div class="mb-3">
             <label for="disease" class="form-label">Disease</label>
-            <input type="text" class="form-control" id="disease" name="disease" value="rheumatoid_arthritis">
+            <input list="disease-list" class="form-control" id="disease" name="disease" value="rheumatoid_arthritis">
+            <datalist id="disease-list"></datalist>
         </div>
         <div class="mb-3">
             <label for="age" class="form-label">Patient Age</label>
@@ -84,5 +85,33 @@
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    async function fetchDiseases(query = '') {
+        const resp = await fetch(`/api/diseases${query ? '?q=' + encodeURIComponent(query) : ''}`);
+        if (!resp.ok) return [];
+        const data = await resp.json();
+        return data.diseases || [];
+    }
+
+    async function updateDiseaseList(query) {
+        const list = document.getElementById('disease-list');
+        list.innerHTML = '';
+        const diseases = await fetchDiseases(query);
+        diseases.forEach(d => {
+            const opt = document.createElement('option');
+            opt.value = d;
+            list.appendChild(opt);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const diseaseInput = document.getElementById('disease');
+        updateDiseaseList('');
+        diseaseInput.addEventListener('input', () => {
+            const q = diseaseInput.value;
+            updateDiseaseList(q);
+        });
+    });
+</script>
 </body>
 </html>

--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -30,3 +30,22 @@ def test_therapeutic_route(monkeypatch):
     resp = client.get("/therapeutic/analyze?gene=PTPN22&variant=R620W&disease=ra")
     assert resp.status_code == 200
     assert called["args"][0] == "PTPN22"
+
+
+def test_disease_api(monkeypatch):
+    from enhancement_engine.core.disease_db import DiseaseDatabaseClient
+
+    def fake_search(self, term, max_results=5):
+        return ["dynamic"] if term else []
+
+    monkeypatch.setattr(DiseaseDatabaseClient, "search_diseases", fake_search)
+
+    client = app.test_client()
+    resp = client.get("/api/diseases")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "rheumatoid_arthritis" in data["diseases"]
+
+    resp = client.get("/api/diseases?q=dyn")
+    data = resp.get_json()
+    assert "dynamic" in data["diseases"]


### PR DESCRIPTION
## Summary
- expose `/api/diseases` endpoint for static and dynamic disease suggestions
- update therapeutic form with datalist autocomplete using the new API
- implement `search_diseases` in the disease DB client
- provide helper `enhancement_engine.webapp` for tests
- test disease suggestion endpoint

## Testing
- `pytest -k webapp_therapeutic -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cbdb2f3883299b8051439e5d0762