### PR TITLE
Normalize disease names in API

### DIFF
--- a/enhancement_engine/core/disease_db.py
+++ b/enhancement_engine/core/disease_db.py
@@ -76,9 +76,15 @@ class DiseaseDatabaseClient:
                 summary = Entrez.read(sum_handle)
                 sum_handle.close()
                 if summary:
-                    name = summary[0].get("Description") or summary[0].get("Title") or summary[0].get("Name")
+                    name = (
+                        summary[0].get("Description")
+                        or summary[0].get("Title")
+                        or summary[0].get("Name")
+                    )
                     if name:
-                        names.append(name)
+                        normalized = name.strip().lower()
+                        if normalized:
+                            names.append(normalized)
             return names
         except Exception as exc:  # pragma: no cover - network errors
             self.logger.warning(f"Failed to search diseases: {exc}")

--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -36,7 +36,9 @@ def test_disease_api(monkeypatch):
     from enhancement_engine.core.disease_db import DiseaseDatabaseClient
 
     def fake_search(self, term, max_results=5):
-        return ["dynamic"] if term else []
+        if term:
+            return ["Dynamic", "dynamic", " dynamic "]
+        return []
 
     monkeypatch.setattr(DiseaseDatabaseClient, "search_diseases", fake_search)
 
@@ -49,3 +51,5 @@ def test_disease_api(monkeypatch):
     resp = client.get("/api/diseases?q=dyn")
     data = resp.get_json()
     assert "dynamic" in data["diseases"]
+    lower = [d.lower() for d in data["diseases"]]
+    assert len(lower) == len(set(lower))

--- a/webapp/run.py
+++ b/webapp/run.py
@@ -213,7 +213,13 @@ def create_app(config: Optional[dict] = None) -> Flask:
                     dynamic = therapeutic_engine.disease_db_client.search_diseases(query)
                 except Exception as e:  # pragma: no cover - network errors
                     app.logger.warning(f"Dynamic disease search failed: {e}")
-            results = sorted(set(results + dynamic))
+
+            combined = {}
+            for name in results + dynamic:
+                key = name.lower()
+                if key not in combined:
+                    combined[key] = name
+            results = sorted(combined.values())
         return jsonify({"diseases": results})
 
     @app.route("/therapeutic", methods=["GET", "POST"])


### PR DESCRIPTION
## Summary
- normalize names returned by the disease DB client
- deduplicate `/api/diseases` suggestions in a case-insensitive manner
- ensure tests confirm unique suggestions when dynamic duplicates are returned

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cfd041808329bc4d9fb3fbaff4ed