### PR TITLE
Add disease info API and frontend autocomplete

### DIFF
--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -62,11 +62,13 @@
     <form method="post">
         <div class="mb-3">
             <label for="gene" class="form-label">Gene Symbol</label>
-            <input type="text" class="form-control" id="gene" name="gene" required>
+            <input list="gene-list" type="text" class="form-control" id="gene" name="gene" required>
+            <datalist id="gene-list"></datalist>
         </div>
         <div class="mb-3">
             <label for="variant" class="form-label">Variant</label>
-            <input type="text" class="form-control" id="variant" name="variant">
+            <input list="variant-list" type="text" class="form-control" id="variant" name="variant">
+            <datalist id="variant-list"></datalist>
         </div>
         <div class="mb-3">
             <label for="disease" class="form-label">Disease</label>
@@ -104,12 +106,50 @@
         });
     }
 
+    let diseaseGeneData = {};
+
+    async function updateGeneList(disease) {
+        const geneList = document.getElementById('gene-list');
+        const variantList = document.getElementById('variant-list');
+        geneList.innerHTML = '';
+        variantList.innerHTML = '';
+        if (!disease) return;
+        const resp = await fetch(`/api/disease_info?disease=${encodeURIComponent(disease)}`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        diseaseGeneData = data.variants || {};
+        (data.genes || []).forEach(g => {
+            const opt = document.createElement('option');
+            opt.value = g;
+            geneList.appendChild(opt);
+        });
+    }
+
+    function updateVariantList(gene) {
+        const variantList = document.getElementById('variant-list');
+        variantList.innerHTML = '';
+        if (!gene || !diseaseGeneData[gene]) return;
+        diseaseGeneData[gene].forEach(v => {
+            const opt = document.createElement('option');
+            opt.value = v;
+            variantList.appendChild(opt);
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
         const diseaseInput = document.getElementById('disease');
+        const geneInput = document.getElementById('gene');
         updateDiseaseList('');
+        updateGeneList(diseaseInput.value);
         diseaseInput.addEventListener('input', () => {
             const q = diseaseInput.value;
             updateDiseaseList(q);
+        });
+        diseaseInput.addEventListener('change', () => {
+            updateGeneList(diseaseInput.value);
+        });
+        geneInput.addEventListener('change', () => {
+            updateVariantList(geneInput.value);
         });
     });
 </script>

--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -53,3 +53,29 @@ def test_disease_api(monkeypatch):
     assert "dynamic" in data["diseases"]
     lower = [d.lower() for d in data["diseases"]]
     assert len(lower) == len(set(lower))
+
+
+def test_disease_info_api(monkeypatch):
+    from enhancement_engine.webapp import run as run_module
+
+    fake = {
+        "cat": {
+            "G1": {
+                "disease_associations": {"dis": {}},
+                "pathogenic_variants": {"v1": {}, "v2": {}}
+            },
+            "G2": {
+                "disease_associations": {"other": {}},
+                "pathogenic_variants": {"x": {}}
+            }
+        }
+    }
+
+    monkeypatch.setattr(run_module, "DISEASE_GENES", fake)
+
+    client = app.test_client()
+    resp = client.get("/api/disease_info?disease=dis")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data["genes"]) == {"G1"}
+    assert set(data["variants"]["G1"]) == {"v1", "v2"}

--- a/webapp/run.py
+++ b/webapp/run.py
@@ -222,6 +222,25 @@ def create_app(config: Optional[dict] = None) -> Flask:
             results = sorted(combined.values())
         return jsonify({"diseases": results})
 
+    @app.route("/api/disease_info", methods=["GET"])
+    def api_disease_info():
+        """Return genes and variants associated with a disease."""
+        disease = request.args.get("disease", "").strip()
+        if not disease:
+            return jsonify({"genes": [], "variants": {}})
+
+        genes = []
+        variants = {}
+        for category in DISEASE_GENES.values():
+            for gene, info in category.items():
+                assoc = info.get("disease_associations", {})
+                if disease in assoc:
+                    genes.append(gene)
+                    vars_for_gene = list(info.get("pathogenic_variants", {}).keys())
+                    variants[gene] = vars_for_gene
+
+        return jsonify({"genes": genes, "variants": variants})
+
     @app.route("/therapeutic", methods=["GET", "POST"])
     def therapeutic():
         """Run therapeutic analysis via simple form."""


### PR DESCRIPTION
## Summary
- expose new `/api/disease_info` for genes and variants
- autocomplete gene and variant fields in therapeutic page
- update JS to fetch disease info and populate datalists
- test disease info route via monkeypatched constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d0d1061c8329a76ee62f74911b4a