### PR TITLE
Improve disease info dropdowns

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -81,8 +81,8 @@
                                 <label for="gene" class="form-label">
                                     <i class="fas fa-atom me-1"></i>Gene Symbol
                                 </label>
-                                <input type="text" class="form-control" id="gene" name="gene" 
-                                       placeholder="e.g., COMT, BDNF, ACTN3" required>
+                                <input type="text" class="form-control" id="gene" name="gene"
+                                       placeholder="e.g., COMT, BDNF, ACTN3" required autocomplete="off">
                                 <div class="invalid-feedback">
                                     Please enter a gene symbol.
                                 </div>
@@ -92,8 +92,8 @@
                                 <label for="variant" class="form-label">
                                     <i class="fas fa-edit me-1"></i>Variant
                                 </label>
-                                <input type="text" class="form-control" id="variant" name="variant" 
-                                    placeholder="e.g., Val158Met">
+                                <input type="text" class="form-control" id="variant" name="variant"
+                                    placeholder="e.g., Val158Met" autocomplete="off">
                                 <div class="form-text">Enter specific variant or use default</div>
                             </div>
                             

--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -62,17 +62,17 @@
     <form method="post">
         <div class="mb-3">
             <label for="gene" class="form-label">Gene Symbol</label>
-            <input list="gene-list" type="text" class="form-control" id="gene" name="gene" required>
+            <input list="gene-list" type="text" class="form-control" id="gene" name="gene" required autocomplete="off">
             <datalist id="gene-list"></datalist>
         </div>
         <div class="mb-3">
             <label for="variant" class="form-label">Variant</label>
-            <input list="variant-list" type="text" class="form-control" id="variant" name="variant">
+            <input list="variant-list" type="text" class="form-control" id="variant" name="variant" autocomplete="off">
             <datalist id="variant-list"></datalist>
         </div>
         <div class="mb-3">
             <label for="disease" class="form-label">Disease</label>
-            <input list="disease-list" class="form-control" id="disease" name="disease" value="rheumatoid_arthritis">
+            <input list="disease-list" class="form-control" id="disease" name="disease" value="rheumatoid_arthritis" autocomplete="off">
             <datalist id="disease-list"></datalist>
         </div>
         <div class="mb-3">


### PR DESCRIPTION
## Summary
- disable browser autocomplete for gene/variant fields
- disable autocomplete for therapeutic disease input
- load gene/variant info from ClinVar when disease not in local constants
- add utility `fetch_associated_genes` in disease database client
- extend tests for dynamic disease info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842c640015c8329a66ba74bf840fb03