### PR TITLE
Fallback disease search in API

### DIFF
--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -148,6 +148,15 @@
         diseaseInput.addEventListener('change', () => {
             updateGeneList(diseaseInput.value);
         });
+        diseaseInput.addEventListener('blur', () => {
+            updateGeneList(diseaseInput.value);
+        });
+        const form = diseaseInput.closest('form');
+        if (form) {
+            form.addEventListener('submit', () => {
+                updateGeneList(diseaseInput.value);
+            });
+        }
         geneInput.addEventListener('change', () => {
             updateVariantList(geneInput.value);
         });


### PR DESCRIPTION
## Summary
- enable caching for disease searches
- search for disease synonyms if the initial query returns no genes
- update therapeutic UI events to query genes when losing focus
- add regression test for disease synonym fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842da428df48329a352c4fad06a0719