### PR TITLE
Handle therapeutic engine failure

### DIFF
--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -92,6 +92,10 @@
         const resp = await fetch(`/api/diseases${query ? '?q=' + encodeURIComponent(query) : ''}`);
         if (!resp.ok) return [];
         const data = await resp.json();
+        if (data.error) {
+            alert(data.error);
+            return [];
+        }
         return data.diseases || [];
     }
 
@@ -117,6 +121,10 @@
         const resp = await fetch(`/api/disease_info?disease=${encodeURIComponent(disease)}`);
         if (!resp.ok) return;
         const data = await resp.json();
+        if (data.error) {
+            alert(data.error);
+            return;
+        }
         diseaseGeneData = data.variants || {};
         (data.genes || []).forEach(g => {
             const opt = document.createElement('option');

--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -144,3 +144,21 @@ def test_disease_info_api_synonym_fallback(monkeypatch):
     assert ("fetch", "unknown") in dummy.calls
     assert ("search", "unknown") in dummy.calls
     assert ("fetch", "synonym") in dummy.calls
+
+
+def test_dynamic_endpoints_unavailable(monkeypatch):
+    from enhancement_engine.webapp import run as run_module
+
+    # Simulate failure during TherapeuticEnhancementEngine initialization
+    monkeypatch.setattr(run_module, "TherapeuticEnhancementEngine", None)
+
+    app = run_module.create_app()
+    client = app.test_client()
+
+    resp = client.get("/api/diseases")
+    assert resp.status_code == 503
+    assert resp.get_json()["error"] == "Therapeutic engine unavailable"
+
+    resp = client.get("/api/disease_info?disease=test")
+    assert resp.status_code == 503
+    assert resp.get_json()["error"] == "Therapeutic engine unavailable"


### PR DESCRIPTION
## Summary
- note failure in config when therapeutic engine can't initialize
- show an error JSON on `/api/diseases` and `/api/disease_info` when therapeutic features fail
- display alert in UI if API returns this error
- test that API returns error when therapeutic engine is missing

## Testing
- `pip install biopython`
- `pip install requests`
- `pip install pandas`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842dd6903608329b88a51e874f7e893