### PR TITLE
Add gene load feedback on therapeutic page

### DIFF
--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -64,6 +64,7 @@
             <label for="gene" class="form-label">Gene Symbol</label>
             <input list="gene-list" type="text" class="form-control" id="gene" name="gene" required autocomplete="off">
             <datalist id="gene-list"></datalist>
+            <div id="gene-message" class="form-text text-danger"></div>
         </div>
         <div class="mb-3">
             <label for="variant" class="form-label">Variant</label>
@@ -111,14 +112,23 @@
     async function updateGeneList(disease) {
         const geneList = document.getElementById('gene-list');
         const variantList = document.getElementById('variant-list');
+        const messageEl = document.getElementById('gene-message');
         geneList.innerHTML = '';
         variantList.innerHTML = '';
+        if (messageEl) messageEl.textContent = '';
         if (!disease) return;
+        if (messageEl) messageEl.textContent = 'Loading...';
         const resp = await fetch(`/api/disease_info?disease=${encodeURIComponent(disease)}`);
+        if (messageEl) messageEl.textContent = '';
         if (!resp.ok) return;
         const data = await resp.json();
         diseaseGeneData = data.variants || {};
-        (data.genes || []).forEach(g => {
+        const genes = data.genes || [];
+        if (genes.length === 0) {
+            if (messageEl) messageEl.textContent = `No genes found for '${disease}'`;
+            return;
+        }
+        genes.forEach(g => {
             const opt = document.createElement('option');
             opt.value = g;
             geneList.appendChild(opt);

--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -144,3 +144,11 @@ def test_disease_info_api_synonym_fallback(monkeypatch):
     assert ("fetch", "unknown") in dummy.calls
     assert ("search", "unknown") in dummy.calls
     assert ("fetch", "synonym") in dummy.calls
+
+
+def test_therapeutic_page_contains_failure_message():
+    client = app.test_client()
+    resp = client.get("/therapeutic")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert "No genes found for" in html


### PR DESCRIPTION
## Summary
- show a small gene message container in `therapeutic.html`
- display loading and no gene message from `updateGeneList`
- test that therapeutic page HTML contains failure message text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842dd673f9483298856bf6dc980b16c