### PR TITLE
Refresh datalist dropdown on dynamic disease search

### DIFF
--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -109,6 +109,12 @@
             opt.value = d;
             list.appendChild(opt);
         });
+        const diseaseInput = document.getElementById('disease');
+        if (document.activeElement === diseaseInput) {
+            diseaseInput.blur();
+            diseaseInput.focus();
+            diseaseInput.dispatchEvent(new Event('input', { bubbles: true }));
+        }
     }
 
     let diseaseGeneData = {};


### PR DESCRIPTION
## Summary
- trigger datalist refresh when diseases are loaded

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432a4e40f08329b07ac4e34efea63a