### PR TITLE
Debounce disease autocomplete

### DIFF
--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -118,6 +118,7 @@
     }
 
     let diseaseGeneData = {};
+    let diseaseTimeout;
 
     async function updateGeneList(disease) {
         const geneList = document.getElementById('gene-list');
@@ -166,8 +167,10 @@
         updateDiseaseList('');
         updateGeneList(diseaseInput.value);
         diseaseInput.addEventListener('input', () => {
-            const q = diseaseInput.value;
-            updateDiseaseList(q);
+            clearTimeout(diseaseTimeout);
+            diseaseTimeout = setTimeout(() => {
+                updateDiseaseList(diseaseInput.value);
+            }, 100);
         });
         diseaseInput.addEventListener('change', () => {
             updateGeneList(diseaseInput.value);


### PR DESCRIPTION
## Summary
- avoid flooding `/api/diseases` by debouncing input events

## Testing
- `pytest -q`
- `node debounce_test.js 2>/dev/null | grep -A1 calls`

------
https://chatgpt.com/codex/tasks/task_e_68432ee89dd48329b46d25ecb88de775