### PR TITLE
Add dynamic disease datalist test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ scipy>=1.9.0
 seaborn>=0.12.0
 urllib3>=1.26.0
 xgboost>=1.6.0
+beautifulsoup4>=4.13.0

--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -238,3 +238,35 @@ def test_disease_info_api_clinvar_synonym(monkeypatch, tmp_path):
     assert data["variants"]["CG"] == ["v1"]
     assert ("search_diseases", "cancer") in calls
     assert ("esearch", "carcinoma") in calls
+
+
+def test_disease_datalist_updates(monkeypatch):
+    """Therapeutic page dynamically loads diseases via /api/diseases."""
+    from enhancement_engine.core.disease_db import DiseaseDatabaseClient
+    from bs4 import BeautifulSoup
+
+    monkeypatch.setattr(
+        DiseaseDatabaseClient,
+        "search_diseases",
+        lambda self, term, max_results=5: ["dynamic disease"],
+    )
+
+    client = app.test_client()
+    page = client.get("/therapeutic")
+    assert page.status_code == 200
+
+    resp = client.get("/api/diseases?q=dynamic")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["diseases"] == ["dynamic disease"]
+
+    soup = BeautifulSoup(page.get_data(as_text=True), "html.parser")
+    dl = soup.find("datalist", id="disease-list")
+    assert dl is not None
+    dl.clear()
+    for name in data["diseases"]:
+        opt = soup.new_tag("option")
+        opt["value"] = name
+        dl.append(opt)
+
+    assert dl.find("option", {"value": "dynamic disease"}) is not None


### PR DESCRIPTION
## Summary
- add BeautifulSoup to requirements
- test dynamic disease datalist functionality in therapeutic page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433037384c8329b7b4030c8091b398