### PR TITLE
Add search field assertion for therapeutic page

### DIFF
--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -188,6 +188,9 @@ def test_therapeutic_page_contains_failure_message():
 
     assert soup.find("button", id="confirm-disease") is not None
 
+    # search field/button should be present for finding diseases dynamically
+    assert soup.find(id="search-disease") is not None
+
     assert "No genes found for" in html
 
     


### PR DESCRIPTION
## Summary
- check that the therapeutic page includes the search button
- verify that tests still pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843452d706483298da1ec09e858962e