### PR TITLE
Add tests for gene variants API and index elements

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -111,8 +111,16 @@
                                 <label for="gene" class="form-label">
                                     <i class="fas fa-atom me-1"></i>Gene Symbol
                                 </label>
-                                <input type="text" class="form-control" id="gene" name="gene"
-                                       placeholder="e.g., COMT, BDNF, ACTN3" required autocomplete="off">
+                                <div class="dropdown">
+                                    <div class="input-group">
+                                        <input type="text" class="form-control" id="gene" name="gene"
+                                               placeholder="e.g., COMT, BDNF, ACTN3" required autocomplete="off">
+                                        <button type="button" class="btn btn-outline-secondary" id="search-gene">
+                                            <i class="fas fa-search"></i>
+                                        </button>
+                                    </div>
+                                    <ul class="dropdown-menu" id="variant-menu"></ul>
+                                </div>
                                 <div class="invalid-feedback">
                                     Please enter a gene symbol.
                                 </div>

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -13,6 +13,9 @@ def test_index_page():
     client = app.test_client()
     resp = client.get("/")
     assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert 'id="search-gene"' in html
+    assert 'id="variant-menu"' in html
 
 
 def test_analyze_route(monkeypatch):
@@ -48,3 +51,16 @@ def test_analyze_route(monkeypatch):
     assert resp.status_code in (200, 405)
     if resp.status_code == 200:
         assert called['gene'] == "COMT"
+
+
+def test_gene_variants_api(monkeypatch):
+    monkeypatch.setattr(
+        EnhancementEngine,
+        "validate_gene_input",
+        lambda self, gene_name: {"available_variants": ["v1", "v2"]},
+    )
+    client = app.test_client()
+    resp = client.get("/api/gene_variants?gene=TEST")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["variants"] == ["v1", "v2"]

--- a/webapp/run.py
+++ b/webapp/run.py
@@ -234,6 +234,23 @@ def create_app(config: Optional[dict] = None) -> Flask:
         
         return jsonify({"diseases": results})
 
+    @app.route("/api/gene_variants", methods=["GET"])
+    def api_gene_variants():
+        """Return available variants for a given gene."""
+        if not engine:
+            return jsonify({"error": "Enhancement Engine not available"}), 503
+
+        gene = request.args.get("gene", "").strip()
+        if not gene:
+            return jsonify({"variants": []})
+
+        try:
+            info = engine.validate_gene_input(gene)
+            return jsonify({"variants": info.get("available_variants", [])})
+        except Exception as exc:
+            app.logger.error(f"Gene variant lookup failed: {exc}")
+            return jsonify({"error": "lookup failed"}), 500
+
     @app.route("/api/disease_info", methods=["GET"])
     def api_disease_info():
         """Return genes and variants associated with a disease."""


### PR DESCRIPTION
## Summary
- verify index page includes search & variant elements
- add test for `/api/gene_variants`
- expose `/api/gene_variants` route
- update index template with search button and variant menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434f2c1bb08329b1e2eecd5033903b