### PR TITLE
Fix therapeutic page test for new UI elements

### DIFF
--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -193,10 +193,9 @@ def test_therapeutic_page_contains_failure_message():
     assert loading is not None
     assert "display:none" in (loading.get("style", "").replace(" ", "").lower())
 
-    assert soup.find("button", id="confirm-disease") is not None
-
     # search field/button should be present for finding diseases dynamically
     assert soup.find(id="search-disease") is not None
+    assert soup.find(id="search-spinner") is not None
 
     assert "No genes found for" in html
 


### PR DESCRIPTION
## Summary
- update `test_therapeutic_page_contains_failure_message` to look for the
  search button and spinner instead of the removed confirm button

## Testing
- `pytest -q tests/test_webapp_therapeutic.py`

------
https://chatgpt.com/codex/tasks/task_e_684352644c248329b0e0d6b97694bfe5