### PR TITLE
Remove duplicate API function

### DIFF
--- a/webapp/run.py
+++ b/webapp/run.py
@@ -237,10 +237,12 @@ def create_app(config: Optional[dict] = None) -> Flask:
     @app.route("/api/gene_variants", methods=["GET"])
     def api_gene_variants():
         """Return available variants for a given gene."""
-        if not engine:
-            return jsonify({"error": "Enhancement Engine not available"}), 503
-
         gene = request.args.get("gene", "").strip()
+
+        if not engine:
+            app.logger.warning("Enhancement Engine not available")
+            return jsonify({"variants": []})
+
         if not gene:
             return jsonify({"variants": []})
 
@@ -249,7 +251,7 @@ def create_app(config: Optional[dict] = None) -> Flask:
             return jsonify({"variants": info.get("available_variants", [])})
         except Exception as exc:
             app.logger.error(f"Gene variant lookup failed: {exc}")
-            return jsonify({"error": "lookup failed"}), 500
+            return jsonify({"variants": []})
 
     @app.route("/api/disease_info", methods=["GET"])
     def api_disease_info():
@@ -298,25 +300,6 @@ def create_app(config: Optional[dict] = None) -> Flask:
 
         return jsonify({"genes": genes, "variants": variants})
 
-    @app.route("/api/gene_variants", methods=["GET"])
-    def api_gene_variants():
-        """Return available variants for the given gene."""
-        gene = request.args.get("gene", "").strip()
-
-        if not engine:
-            app.logger.warning("Enhancement Engine not initialized")
-            return jsonify({"variants": []})
-
-        if not gene:
-            return jsonify({"variants": []})
-
-        try:
-            result = engine.validate_gene_input(gene)
-            variants = result.get("available_variants", [])
-            return jsonify({"variants": variants})
-        except Exception as exc:  # pragma: no cover - unexpected errors
-            app.logger.warning(f"Gene variant lookup failed: {exc}")
-            return jsonify({"variants": []})
 
     @app.route("/therapeutic", methods=["GET", "POST"])
     def therapeutic():


### PR DESCRIPTION
## Summary
- clean up duplicate `api_gene_variants` routes
- return empty variant lists when gene or engine is missing

## Testing
- `pytest tests/test_webapp.py::test_gene_variants_api -vv`
- `python webapp/run.py` (started then killed)

------
https://chatgpt.com/codex/tasks/task_e_684353186a88832988b89a85a8746e84