### PR TITLE
Fix variant dropdown placement

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,6 @@
                                             <i class="fas fa-search"></i>
                                         </button>
                                     </div>
-                                    <ul class="dropdown-menu" id="variant-menu"></ul>
                                 </div>
                                 <div class="invalid-feedback">
                                     Please enter a gene symbol.
@@ -130,9 +129,11 @@
                                 <label for="variant" class="form-label">
                                     <i class="fas fa-edit me-1"></i>Variant
                                 </label>
-                                <input type="text" class="form-control" id="variant" name="variant"
-                                    placeholder="e.g., Val158Met" autocomplete="off">
-                                <ul class="dropdown-menu" id="variant-menu" style="display:none;"></ul>
+                                <div class="dropdown">
+                                    <input type="text" class="form-control" id="variant" name="variant"
+                                           placeholder="e.g., Val158Met" autocomplete="off">
+                                    <ul class="dropdown-menu" id="variant-menu" style="display:none;"></ul>
+                                </div>
                                 <div class="form-text">Enter specific variant or use default</div>
                             </div>
                             


### PR DESCRIPTION
## Summary
- adjust gene input layout to drop unused variant dropdown
- wrap variant field in a dropdown container
- keep JS logic for populating and displaying variant suggestions

## Testing
- `pytest -q` *(fails: BioPython missing)*

------
https://chatgpt.com/codex/tasks/task_e_684356ad1ee4832996933f0a98b4fb00