### PR TITLE
Update variant dropdown check in therapeutic tests

### DIFF
--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -87,6 +87,7 @@
                 <label for="variant" class="form-label">Variant</label>
                 <input list="variant-list" type="text" class="form-control" id="variant" name="variant" autocomplete="off">
                 <datalist id="variant-list"></datalist>
+                <ul class="dropdown-menu" id="variant-menu"></ul>
             </div>
         </div>
         <div class="mb-3">

--- a/tests/test_webapp_therapeutic.py
+++ b/tests/test_webapp_therapeutic.py
@@ -186,6 +186,9 @@ def test_therapeutic_page_contains_failure_message():
     assert gv is not None
     assert "display:none" in (gv.get("style", "").replace(" ", "").lower())
 
+    # dropdown menu for variants should be present
+    assert soup.find(id="variant-menu") is not None
+
     # dropdown list for dynamic disease search should be present
     assert soup.find(id="disease-results") is not None
 


### PR DESCRIPTION
## Summary
- verify the therapeutic page has a `variant-menu` element
- add a matching dropdown menu in the template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684356b020a8832995e14f536a55e674