### PR TITLE
Fix disease dropdown and flash display

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -93,13 +93,17 @@
         <div class="row justify-content-center">
             <div class="col-lg-8">
                 <div class="form-container">
-                    <!-- Error Alert -->
-                    {% if error %}
-                    <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                        <i class="fas fa-exclamation-triangle me-2"></i>{{ error }}
-                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                    </div>
+                    <!-- Flash Messages -->
+                    {% with messages = get_flashed_messages(with_categories=true) %}
+                    {% if messages %}
+                        {% for category, message in messages %}
+                        <div class="alert alert-{{ 'danger' if category == 'error' else category }} alert-dismissible fade show" role="alert">
+                            {{ message }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        </div>
+                        {% endfor %}
                     {% endif %}
+                    {% endwith %}
 
                     <h2 class="text-center mb-4">
                         <i class="fas fa-search me-2"></i>Gene Analysis

--- a/templates/therapeutic.html
+++ b/templates/therapeutic.html
@@ -62,14 +62,12 @@
     <form method="post">
         <div class="mb-3">
             <label for="disease" class="form-label">Disease</label>
-            <div class="dropdown">
-                <div class="input-group">
-                    <input type="text" class="form-control" id="disease" name="disease" value="rheumatoid_arthritis" autocomplete="off">
-                    <button type="button" class="btn btn-outline-secondary" id="search-disease">
-                        <i id="search-icon" class="fas fa-search"></i>
-                        <span class="loading-spinner" id="search-spinner" style="display:none;"></span>
-                    </button>
-                </div>
+            <div class="input-group dropdown">
+                <input type="text" class="form-control" id="disease" name="disease" value="rheumatoid_arthritis" autocomplete="off">
+                <button type="button" class="btn btn-outline-secondary" id="search-disease">
+                    <i id="search-icon" class="fas fa-search"></i>
+                    <span class="loading-spinner" id="search-spinner" style="display:none;"></span>
+                </button>
                 <ul class="dropdown-menu" id="disease-results"></ul>
             </div>
             <div id="gene-loading" class="mt-2" style="display:none;">


### PR DESCRIPTION
## Summary
- ensure disease dropdown in therapeutic page shows results by making the dropdown menu a sibling of the search button
- display flashed error messages on the index page so they are not carried over to other pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843298c97308329827e236a99c19864